### PR TITLE
Pair error handler restoration properly

### DIFF
--- a/src/IconvTranscoder.php
+++ b/src/IconvTranscoder.php
@@ -34,10 +34,13 @@ class IconvTranscoder implements TranscoderInterface
             },
             E_NOTICE | E_USER_NOTICE
         );
-        
-        $result = iconv($from, $to ?: $this->defaultEncoding, $string);
-        restore_error_handler();
-        
+
+        try {
+            $result = iconv($from, $to ?: $this->defaultEncoding, $string);
+        } finally {
+            restore_error_handler();
+        }
+
         return $result;
     }
 }

--- a/src/MbTranscoder.php
+++ b/src/MbTranscoder.php
@@ -41,7 +41,12 @@ class MbTranscoder implements TranscoderInterface
             }
         }
 
-        if (!$from || 'auto' === $from) {
+        if ($to) {
+            $this->assertSupported($to);
+        }
+
+        $handleErrors = !$from || 'auto' === $from;
+        if ($handleErrors) {
             set_error_handler(
                 function ($no, $warning) use ($string) {
                     throw new UndetectableEncodingException($string, $warning);
@@ -50,19 +55,18 @@ class MbTranscoder implements TranscoderInterface
             );
         }
 
-        
-        if ($to) {
-            $this->assertSupported($to);
+        try {
+            $result = mb_convert_encoding(
+                $string,
+                $to ?: $this->defaultEncoding,
+                $from ?: 'auto'
+            );
+        } finally {
+            if ($handleErrors) {
+                restore_error_handler();
+            }
         }
-        
-        $result = mb_convert_encoding(
-            $string,
-            $to ?: $this->defaultEncoding,
-            $from ?: 'auto'
-        );
-        
-        restore_error_handler();
-        
+
         return $result;
     }
     


### PR DESCRIPTION
Previously, the error handlers in IconvTranscoder and MbTranscoder were not restored on error because exception was raised. And what is worse, MbTranscoder popped the error handler stack even when it did not push into it.

Let’s fix the former by restoring in a finally block (not catching the raised exception), and the latter by restoring only conditionally.

